### PR TITLE
Deal with lists that have extra lines between them.

### DIFF
--- a/lib/reverse_markdown/converters/li.rb
+++ b/lib/reverse_markdown/converters/li.rb
@@ -2,10 +2,14 @@ module ReverseMarkdown
   module Converters
     class Li < Base
       def convert(node, state = {})
-        content     = treat_children(node, state)
-        indentation = indentation_from(state)
-        prefix      = prefix_for(node)
-        "#{indentation}#{prefix}#{content.chomp}\n"
+        contains_child_paragraph = node.children.first&.name == 'p'
+        content_node             = contains_child_paragraph ? node.children.first : node
+        content                  = treat_children(content_node, state)
+        indentation              = indentation_from(state)
+        prefix                   = prefix_for(node)
+
+        "#{indentation}#{prefix}#{content.chomp}\n" +
+          (contains_child_paragraph ? "\n" : '')
       end
 
       def prefix_for(node)

--- a/lib/reverse_markdown/converters/li.rb
+++ b/lib/reverse_markdown/converters/li.rb
@@ -2,7 +2,7 @@ module ReverseMarkdown
   module Converters
     class Li < Base
       def convert(node, state = {})
-        contains_child_paragraph = node.children.first&.name == 'p'
+        contains_child_paragraph = node.children.first ? node.children.first.name == 'p' : false
         content_node             = contains_child_paragraph ? node.children.first : node
         content                  = treat_children(content_node, state)
         indentation              = indentation_from(state)

--- a/spec/html_to_markdown_to_html_spec.rb
+++ b/spec/html_to_markdown_to_html_spec.rb
@@ -52,6 +52,16 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
     ")
   end
 
+  it "should preserve lists with paragraphs" do
+    roundtrip_should_preserve("
+      <ul>
+        <li><p>Bird</p></li>
+        <li><p>McHale</p></li>
+        <li><p>Parish</p></li>
+      </ul>
+      ")
+  end
+
   it "should preserve <hr> tags" do
     roundtrip_should_preserve("<hr />")
   end


### PR DESCRIPTION
It's possible to have lists that have a blank line between each list item.

For example:

```
1. This is one line

2. This is the next line

```

This converts to the following html:

```
<ol>
  <li><p>This is one line</p></li>
  <li><p>This is the next line</p></li>
</ol>
```

This commit checks for the presence of the paragraph inside the list item.